### PR TITLE
Added cygwin support for opening urls

### DIFF
--- a/autoload/www/system_helper.vim
+++ b/autoload/www/system_helper.vim
@@ -1,6 +1,11 @@
 "Returns whether it is a windows system or not
-function! www#system_helper#is_windows() "{{{
+function! www#system_helper#is_windows()
   return has('win32') || has('win64') || has('win95') || has('win16')
+endfunction
+
+"Returns whether it is a Cygwin on windows system or not
+function! www#system_helper#is_cygwin()
+  return has('win32unix')
 endfunction
 
 "Returns whether it is a macunix system or not

--- a/autoload/www/url_handler.vim
+++ b/autoload/www/url_handler.vim
@@ -12,6 +12,9 @@ function! www#url_handler#handle(cli, url)
     elseif www#system_helper#is_windows()
       call www#url_handler#handle_in_win(a:url)
       return
+    elseif www#system_helper#is_cygwin()
+      call www#url_handler#handle_in_cygwin(a:url)
+      return
     elseif www#system_helper#is_macunix()
       call www#url_handler#handle_in_macunix(a:url)
       return
@@ -44,6 +47,12 @@ endfunction
 "Open given url in a browser in windows
 function! www#url_handler#handle_in_win(url)
    execute 'silent ! start "Title" /B '.shellescape(a:url, 1)
+endfunction
+
+"Open given url in a browser in windows from Cygwin
+function! www#url_handler#handle_in_cygwin(url)
+   execute 'silent ! cygstart '.shellescape(a:url, 1)
+   redraw!
 endfunction
 
 "Open given url in a browser in macunix

--- a/plugin/www.vim
+++ b/plugin/www.vim
@@ -51,8 +51,8 @@ if g:www_map_keys
    nnoremap <leader>wo :call www#www#open_url(0, expand("<cWORD>"))<CR>
    nnoremap <leader>wco :call www#www#open_url(1, expand("<cWORD>"))<CR>
    "Open visual selection as url
-   vnoremap <leader>wo :call www#www#open_url(0, @*)<CR>
-   vnoremap <leader>wco :call www#www#open_url(1, @*)<CR>
+   vnoremap <leader>wo "*y:call www#www#open_url(0, @*)<CR>
+   vnoremap <leader>wco "*y:call www#www#open_url(1, @*)<CR>
    "Search WORD under the cursor
    nnoremap <leader>ws :call www#www#user_input_search(0, expand("<cWORD>"))<CR>
    nnoremap <leader>wcs :call www#www#user_input_search(1, expand("<cWORD>"))<CR>

--- a/plugin/www.vim
+++ b/plugin/www.vim
@@ -57,8 +57,8 @@ if g:www_map_keys
    nnoremap <leader>ws :call www#www#user_input_search(0, expand("<cWORD>"))<CR>
    nnoremap <leader>wcs :call www#www#user_input_search(1, expand("<cWORD>"))<CR>
    "Search visual selection
-   vnoremap <leader>ws :call www#www#user_input_search(0, @*)<CR>
-   vnoremap <leader>wcs :call www#www#user_input_search(1, @*)<CR>
+   vnoremap <leader>ws "gy:call www#www#user_input_search(0, @g)<CR>
+   vnoremap <leader>wcs "gy:call www#www#user_input_search(1, @g)<CR>
 endif
 
 " Define user configured commands and maps that are a shortcut to search using given engines. Definition have to be made in g:www_shortcut_engines, which have to be a dictionary { engine: [command, mappings, cli_command, cli_mappings]}. For each entry, dynamic {command}/{cli_command} commands, and {mappings}/{cli_mappings} normal & visual mappings are defined that work just as Wsearch/Wcsearch and ws/wcs
@@ -74,14 +74,14 @@ if exists('g:www_shortcut_engines')
     endif
     if !empty(mapping)
       execute "nnoremap ".mapping." :call www#www#search(0, '".engine."', expand(\"<cWORD>\"))<CR>"
-      execute "vnoremap ".mapping." :call www#www#search(0, '".engine."', @*)<CR>"
+      execute "vnoremap ".mapping." \"gy:call www#www#search(0, '".engine."', @g)<CR>"
     endif
     if !empty(cli_command)
       execute "command -nargs=1 ".cli_command." call www#www#search(1, '".engine."', <f-args>)"
     endif
     if !empty(cli_mapping)
       execute "nnoremap ".cli_mapping." :call www#www#search(1, '".engine."', expand(\"<cWORD>\"))<CR>"
-      execute "vnoremap ".cli_mapping." :call www#www#search(1, '".engine."', @*)<CR>"
+      execute "vnoremap ".cli_mapping." \"gy:call www#www#search(1, '".engine."', @g)<CR>"
     end
   endfor
 endif

--- a/plugin/www.vim
+++ b/plugin/www.vim
@@ -57,8 +57,8 @@ if g:www_map_keys
    nnoremap <leader>ws :call www#www#user_input_search(0, expand("<cWORD>"))<CR>
    nnoremap <leader>wcs :call www#www#user_input_search(1, expand("<cWORD>"))<CR>
    "Search visual selection
-   vnoremap <leader>ws "gy:call www#www#user_input_search(0, @g)<CR>
-   vnoremap <leader>wcs "gy:call www#www#user_input_search(1, @g)<CR>
+   vnoremap <leader>ws "*y:call www#www#user_input_search(0, @*)<CR>
+   vnoremap <leader>wcs "*y:call www#www#user_input_search(1, @*)<CR>
 endif
 
 " Define user configured commands and maps that are a shortcut to search using given engines. Definition have to be made in g:www_shortcut_engines, which have to be a dictionary { engine: [command, mappings, cli_command, cli_mappings]}. For each entry, dynamic {command}/{cli_command} commands, and {mappings}/{cli_mappings} normal & visual mappings are defined that work just as Wsearch/Wcsearch and ws/wcs
@@ -74,14 +74,14 @@ if exists('g:www_shortcut_engines')
     endif
     if !empty(mapping)
       execute "nnoremap ".mapping." :call www#www#search(0, '".engine."', expand(\"<cWORD>\"))<CR>"
-      execute "vnoremap ".mapping." \"gy:call www#www#search(0, '".engine."', @g)<CR>"
+      execute "vnoremap ".mapping." \"*y:call www#www#search(0, '".engine."', @*)<CR>"
     endif
     if !empty(cli_command)
       execute "command -nargs=1 ".cli_command." call www#www#search(1, '".engine."', <f-args>)"
     endif
     if !empty(cli_mapping)
       execute "nnoremap ".cli_mapping." :call www#www#search(1, '".engine."', expand(\"<cWORD>\"))<CR>"
-      execute "vnoremap ".cli_mapping." \"gy:call www#www#search(1, '".engine."', @g)<CR>"
+      execute "vnoremap ".cli_mapping." \"*y:call www#www#search(1, '".engine."', @*)<CR>"
     end
   endfor
 endif


### PR DESCRIPTION
Check for cygwin on windows system and use `cygpath` to open urls which use the default browser in windows.
When searching text in visual selection, copy the text to a register and then substtitute into the search query.